### PR TITLE
fix bug in ruleset

### DIFF
--- a/DavidLienhard/ruleset.xml
+++ b/DavidLienhard/ruleset.xml
@@ -120,9 +120,9 @@
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon" />
     <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable" />
     <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction" />
-    <rule ref="SlevomatCodingStandard.Functions.RequireSingleLineCall">
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
+    <rule ref="SlevomatCodingStandard.Functions.RequireSingleLineCall">
         <properties>
             <property name="maxLineLength" value="70"/>
         </properties>


### PR DESCRIPTION
fix wrong placement for `properties` belonging to `RequireSingleLineCall`