### PR TITLE
fix typo in ruleset

### DIFF
--- a/DavidLienhard/ruleset.xml
+++ b/DavidLienhard/ruleset.xml
@@ -122,7 +122,7 @@
     <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction" />
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
-    <rule reg="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
+    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
     <rule ref="SlevomatCodingStandard.Functions.RequireSingleLineCall">
         <properties>
             <property name="maxLineLength" value="70"/>


### PR DESCRIPTION
use `ref` instead of `reg`