### PR TITLE
ternary operators

### DIFF
--- a/DavidLienhard/ruleset.xml
+++ b/DavidLienhard/ruleset.xml
@@ -125,6 +125,9 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
 
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator" />
+
     <rule ref="SlevomatCodingStandard.Variables.UnusedVariable">
         <properties>
             <property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true" />


### PR DESCRIPTION
 - require ternary operators to be used when possible
 - require short ternary to be used if possible