### PR TITLE
add DisallowTrailingMultiLineTernaryOperator rule

### DIFF
--- a/DavidLienhard/ruleset.xml
+++ b/DavidLienhard/ruleset.xml
@@ -137,6 +137,7 @@
 
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator" />
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperator" />
 
     <rule ref="SlevomatCodingStandard.Variables.UnusedVariable">
         <properties>


### PR DESCRIPTION
add new rule to disallow trailing ternary operators for multiline